### PR TITLE
Persiste Owners quando o bot é iniciado.

### DIFF
--- a/src/main/java/com/bot/spider/enums/Role.java
+++ b/src/main/java/com/bot/spider/enums/Role.java
@@ -1,6 +1,7 @@
 package com.bot.spider.enums;
 
 public enum Role {
+    OWNER,
     ADMIN,
     USER
 }

--- a/src/main/java/com/bot/spider/repository/UserRepository.java
+++ b/src/main/java/com/bot/spider/repository/UserRepository.java
@@ -4,4 +4,5 @@ import com.bot.spider.models.UserModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserModel, Long> {
+    UserModel findByUsername(String username);
 }

--- a/src/main/java/com/bot/spider/services/InitializationService.java
+++ b/src/main/java/com/bot/spider/services/InitializationService.java
@@ -1,0 +1,73 @@
+package com.bot.spider.services;
+
+import com.bot.spider.enums.Role;
+import com.bot.spider.enums.UserStatus;
+import com.bot.spider.models.UserModel;
+import com.bot.spider.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Objects;
+
+@Component
+public class InitializationService implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${telegram.bot.owners}")
+    private String ownersJsonString;
+
+    @Autowired
+    public InitializationService(UserRepository userRepository, ObjectMapper objectMapper) {
+        this.userRepository = userRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void run(String... args){
+        if (!ownersJsonString.isEmpty()){
+            try {
+                List<Map<String, Object>> ownersFromFile = objectMapper.readValue(
+                        ownersJsonString,
+                        new TypeReference<>() {
+                        }
+                );
+
+                for (Map<String, Object> ownerData : ownersFromFile) {
+                    String firstName = (String) ownerData.get("firstName");
+                    String lastName = (String) ownerData.get("lastName");
+                    String username = (String) ownerData.get("username");
+
+
+                    UserModel existingOwner = userRepository.findByUsername(username);
+
+                    if (Objects.isNull(existingOwner)) {
+                        UserModel newOwner = new UserModel();
+                        newOwner.setFirstName(firstName);
+                        newOwner.setLastName(lastName);
+                        newOwner.setUsername(username);
+                        newOwner.setRole(Role.OWNER);
+                        newOwner.setStatus(UserStatus.ACTIVE);
+                        userRepository.save(newOwner);
+
+                    }
+                }
+            } catch (IOException e) {
+                System.out.println("Error persisting data, error: " + e);
+            }
+
+
+        }
+
+    }
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,4 @@ telegram.bot.api-url=${TELEGRAM_BOT_API_URL}
 telegram.bot.webhook-path=/webhook
 telegram.bot.username=${TELEGRAM_BOT_USERNAME}
 telegram.bot.secret-token=${TELEGRAM_BOT_SECRET_TOKEN}
+telegram.bot.owners=${TELEGRAM_BOT_OWNERS}


### PR DESCRIPTION
**Melhoria no Gerenciamento de Proprietários na Inicialização do Bot**

Este pull request introduz um novo método para a persistência dos dados dos proprietários durante a inicialização do bot.

Utilizando a interface `CommandLineRunner`, os dados dos usuários `owners` serão automaticamente persistidos no início da execução da aplicação. Além disso, foi implementada uma configuração de variável de ambiente no arquivo `application.properties` para permitir a definição de uma lista de `owners` a serem persistidos.

Essa atualização visa aprimorar a facilidade de uso e a flexibilidade da aplicação, fornecendo uma maneira simples e configurável de gerenciar os `owners` diretamente durante a inicialização.